### PR TITLE
Docs: renamed cast to typecast in WOQL.typecast example

### DIFF
--- a/docs/api/woql.js.md
+++ b/docs/api/woql.js.md
@@ -1015,7 +1015,7 @@ Casts the value of Input to a new value of type Type and stores the result in Ca
 
 **Example**  
 ```js
-cast("22/3/98", "xsd:dateTime", "v:time")
+typecast("22/3/98", "xsd:dateTime", "v:time")
 ```
 
 ### order_by


### PR DESCRIPTION
`WOQL.typecast` and `WOQL.cast` seem to be identical. Nonetheless naming should be consistent here