### PR TITLE
Extend cleanObject() to handle booleans

### DIFF
--- a/lib/query/woqlCore.js
+++ b/lib/query/woqlCore.js
@@ -308,6 +308,9 @@ WOQLQuery.prototype.cleanObject = function(o, t) {
     } else if (typeof o == 'object' && o) {
         if (o['@value']) obj['woql:datatype'] = o
         else return o
+    } else if (typeof o == 'boolean') {
+      t = t || 'xsd:boolean'
+      obj['woql:datatype'] = this.jlt(o, t)
     }
     return obj
 }


### PR DESCRIPTION
WOQLQuery.prototype.cleanObject is supposed to transform values (e.g. strings and numbers) into the appropriate json-ld form. So far, this did not cover booleans.

This proposal allows to write
```js
WOQL.triple('v:doc', 'scm:myBooleanProperty', false)
```
instead of the more cumbersome
```js
WOQL.triple('v:doc', 'scm:myBooleanProperty', { '@type': 'xsd:boolean', '@value': true })
```

see this [discord discussion](https://discord.com/channels/689805612053168129/689886415491825703/869867176583118918) for more context