### PR TITLE
Updates to allow dictionary templating

### DIFF
--- a/lib/query/woqlCore.js
+++ b/lib/query/woqlCore.js
@@ -2,6 +2,39 @@
 const UTILS = require('../utils')
 const WOQLPrinter = require('./woqlPrinter')
 
+function convert(obj){
+    if (obj == null){
+        return null
+    } else if (typeof(obj) == 'number'){
+        return { '@type' : 'Value',
+                 'data' : { '@type' : 'xsd:decimal',
+                            '@value' : obj }}
+    } else if (typeof(obj) == 'boolean'){
+        return { '@type' : 'Value',
+                 'data' : { '@type' : 'xsd:boolean',
+                            '@value' : obj }}
+    } else if (typeof(obj) == 'str'){
+        return { '@type' : 'Value',
+                 'data' : { '@type' : 'xsd:string',
+                            '@value' : obj }}
+    } else if (typeof(obj) == 'object'){
+        var pairs = []
+        for (const [key, value] of Object.entries(obj)) {
+            pairs.push({ '@type' : 'FieldValuePair',
+                         'field' : key,
+                         'value' : convert(value) })
+        }
+        return { '@type' : 'DictionaryTemplate',
+                 'data' : pairs }
+    }
+}
+
+function Var(name) { this.name = name }
+function Doc(obj) {
+    this.doc = obj
+    this.encoded = convert(obj)
+}
+
 /**
  * defines the internal functions of the woql query object - the language API is defined in WOQLQuery
  * @module WOQLQuery
@@ -102,6 +135,7 @@ WOQLQuery.prototype.jlt = function(val, type) {
 }
 
 WOQLQuery.prototype.varj = function(varb) {
+    if (varb instanceof Var) varb = varb.name
     if (varb.substring(0, 2) == 'v:') varb = varb.substring(2)
     if (typeof varb == 'string')
         return {
@@ -112,6 +146,7 @@ WOQLQuery.prototype.varj = function(varb) {
 }
 
 WOQLQuery.prototype.rawVar = function(varb) {
+    if (varb instanceof Var) return varb.name
     if (varb.substring(0, 2) === 'v:') varb = varb.substring(2)
     return varb
 }
@@ -250,7 +285,9 @@ WOQLQuery.prototype.cleanSubject = function(s) {
      * @type {any}
      */
     let subj = false
-    if (typeof s === 'object') {
+    if (s instanceof Var){
+        return this.expandNodeVariable(s)
+    } else if (typeof s === 'object') {
         return s
     } else if (typeof s === 'string') {
         if (s.indexOf('v:') !== -1) subj = s
@@ -269,6 +306,7 @@ WOQLQuery.prototype.cleanPredicate = function(p) {
     * @type {any}
     */
     let pred = false
+    if (p instanceof Var) return this.expandNodeVariable(p)
     if (typeof p === 'object') return p
     if (typeof p !== 'string') {
         this.parameterError('Predicate must be a URI string')
@@ -305,7 +343,11 @@ WOQLQuery.prototype.cleanPathPredicate = function(p) {
  */
 WOQLQuery.prototype.cleanObject = function(o, t) {
     let obj = {'@type': 'Value'}
-    if (typeof o === 'string') {
+    if (o instanceof Var){
+        return this.expandValueVariable(o)
+    } else if (o instanceof Doc){
+        return o.encoded
+    } else if (typeof o === 'string') {
         if (o.indexOf('v:') !== -1) {
             return this.expandValueVariable(o)
         } else {
@@ -329,7 +371,11 @@ WOQLQuery.prototype.cleanObject = function(o, t) {
 
 WOQLQuery.prototype.cleanDataValue = function(o, t) {
     let obj = {'@type': 'DataValue'}
-    if (typeof o === 'string') {
+    if (o instanceof Var){
+        return this.expandDataVariable(o)
+    } else if (o instanceof Doc){
+        return o.encoded
+    } else if (typeof o === 'string') {
         if (o.indexOf('v:') !== -1) {
             return this.expandDataVariable(o)
         }else{
@@ -356,7 +402,9 @@ WOQLQuery.prototype.cleanDataValue = function(o, t) {
 
 WOQLQuery.prototype.cleanArithmeticValue = function(o, t) {
     let obj = {'@type': 'ArithmeticValue'}
-    if (typeof o === 'string') {
+    if (o instanceof Var){
+        return this.expandArithmeticVariable(o)
+    } else if (typeof o === 'string') {
         if (o.indexOf('v:') !== -1) {
             return this.expandArithmeticVariable(o)
         }else{
@@ -374,7 +422,9 @@ WOQLQuery.prototype.cleanArithmeticValue = function(o, t) {
 
 WOQLQuery.prototype.cleanNodeValue = function(o, t) {
     let obj = {'@type': 'NodeValue'}
-    if (typeof o === 'string') {
+    if (o instanceof Var){
+        return this.expandNodeVariable(o)
+    } else if (typeof o === 'string') {
         if (o.indexOf('v:') !== -1) {
             return this.expandNodeVariable(o)
         } else {
@@ -398,7 +448,12 @@ WOQLQuery.prototype.cleanGraph = function(g) {
  * @param varname - will be transformed if it starts with v:
  */
 WOQLQuery.prototype.expandVariable = function(varname,type,always) {
-    if (varname.substring(0, 2) == 'v:' || always) {
+    if (varname instanceof Var){
+        return {
+            '@type' : type,
+            'variable' : varname.name
+        }
+    } else if (varname.substring(0, 2) == 'v:' || always) {
         if (varname.substring(0, 2) == 'v:') varname = varname.substring(2)
         return {
             '@type': type,

--- a/lib/woql.js
+++ b/lib/woql.js
@@ -1151,7 +1151,7 @@ WOQL.iri = function(val) {
  */
 
 WOQL.vars = function(...varNames) {
-    return varNames.map(item => 'v:' + item)
+    return varNames.map(item => Var(item))
 }
 
 /**


### PR DESCRIPTION
This change allows us to do queries with arbitrary dictionaries which have embedded in them variables which can be used for matching. This also always us to save these queries in TerminusDB using the WOQL ontology.