### PR TITLE
Fix the broken branch optimize function

### DIFF
--- a/lib/connectionConfig.js
+++ b/lib/connectionConfig.js
@@ -565,7 +565,7 @@ ConnectionConfig.prototype.commitDescriptorUrl = function(commitId) {
 ConnectionConfig.prototype.optimizeBranchUrl = function(branchId) {
     //let o = this.optimizeBase()
     const dbBase = this.dbBase('optimize')
-    return `${dbBase}${this.repoid}/branch/${encodeURIComponent(branchId)}`
+    return `${dbBase}/${this.repoid}/branch/${encodeURIComponent(branchId)}`
     //return dbBase + `${this.user()}/${this.db()}/${this.repoid}/branch/${nuid}`
 }
 

--- a/lib/woqlClient.js
+++ b/lib/woqlClient.js
@@ -620,7 +620,7 @@ WOQLClient.prototype.resetBranch = function(branchId, commitId) {
  * @returns {Promise} A promise that returns the call response object, or an Error if rejected.
  */
 WOQLClient.prototype.optimizeBranch = function(branchId) {
-    return this.dispatch(CONST.OPTIMIZE_SYSTEM, this.connectionConfig.optimizeBranchUrl(branchId))
+    return this.dispatch(CONST.OPTIMIZE_SYSTEM, this.connectionConfig.optimizeBranchUrl(branchId), {})
 }
 
 /**

--- a/test/connectionConfing.spec.js
+++ b/test/connectionConfing.spec.js
@@ -66,7 +66,7 @@ describe('connectionConfig tests', function() {
     })
 
     it('check set branch', function() {
-        const optimizeUrl = 'http://localhost:6363/api/optimize/admin/testDBlocal/branch/%23%23branch01'
+        const optimizeUrl = 'http://localhost:6363/api/optimize/admin/testDB/local/branch/%23%23branch01'
         /*
          * the dbURL dosen't change
          */


### PR DESCRIPTION
The branch optimize function was broken and the tests look strange as well with a missing slash. Also, the POST itself does not need the empty object payload, but is required by the javascript implementation.

It works with the updates, but the optimize branch function is missing how to optimise local/_commits and _meta which would be relevant to add as optimizeMeta and optimizeCommits functions perhaps, or in some other way?