### PR TITLE
Adding token auth rather than API_TOKEN special header

### DIFF
--- a/lib/dispatchRequest.js
+++ b/lib/dispatchRequest.js
@@ -78,7 +78,7 @@ function DispatchRequest(url, action, payload, local_auth, remote_auth = null, c
   } else if (local_auth && local_auth.type === 'jwt') {
     options.headers = { Authorization: `Bearer ${local_auth.key}` };
   } else if (local_auth && local_auth.type === 'apikey') {
-    options.headers = { API_TOKEN: local_auth.key };
+    options.headers = { Authorization: `Token ${local_auth.key}` };
   }
 
   /*


### PR DESCRIPTION
Bad header creates problems with CORS. Move to a proper Auth header.