### PR TITLE
Fix for updateDatabase (issue #246)

### DIFF
--- a/docs/api/woqlclient.md
+++ b/docs/api/woqlclient.md
@@ -550,6 +550,23 @@ of the current context for "commits" "meta" "branch" and "ref" special resources
 const branch_resource = client.resource("branch")
 ```
 
+## module_WOQLClient..WOQLClient+updateDatabase
+##### woqlClient.updateDatabase(dbId, dbDetails, [orgId]) ⇒ <code>Promise</code>
+Update a database in TerminusDB server
+
+**Returns**: <code>Promise</code> - A promise that returns the call response object, or an Error if rejected.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| dbId | <code>string</code> | The id of the database to be updated |
+| dbDetails | <code>typedef.DbDetails</code> | object containing details about the database to be updated |
+| [orgId] | <code>string</code> | optional organization id - if absent default local organization id is used |
+
+**Example**  
+```javascript
+client.updateDatabase({id: "mydb", label: "My Database", comment: "Testing"})
+```
+
 ## module_WOQLClient..WOQLClient+insertTriples
 ##### woqlClient.insertTriples(graphType, turtle, commitMsg) ⇒ <code>Promise</code>
 Appends the passed turtle to the contents of a graph
@@ -700,17 +717,6 @@ Adds an author string (from the user object returned by connect) to the commit m
 | Param | Type |
 | --- | --- |
 | [rc_args] | <code>object</code> | 
-
-
-## module_WOQLClient..WOQLClient+updateDatabase
-##### woqlClient.updateDatabase(dbDoc) ⇒ <code>Promise</code>
-update the database details
-
-**Returns**: <code>Promise</code> - A promise that returns the call response object, or an Error if rejected.  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| dbDoc | <code>object</code> | an object that describe the database details |
 
 
 ## module_WOQLClient..WOQLClient+addDocument

--- a/lib/woqlClient.js
+++ b/lib/woqlClient.js
@@ -459,6 +459,35 @@ WOQLClient.prototype.createDatabase = function (dbId, dbDetails, orgId) {
 };
 
 /**
+ * Update a database in TerminusDB server
+ * @param {string} dbId - The id of the database to be updated
+ * @param {typedef.DbDetails} dbDetails - object containing details about the database to be updated
+ * @param {string} [orgId] - optional organization id - if absent default local organization
+ * id is used
+ * @returns {Promise} A promise that returns the call response object, or an Error if rejected.
+ * @example
+ * client.updateDatabase({id: "mydb", label: "My Database", comment: "Testing"})
+ */
+WOQLClient.prototype.updateDatabase = function (dbDoc) {
+  const dbid = dbDoc.id || this.db();
+  this.organization(dbDoc.organization || this.organization());
+  if (dbid) {
+    this.db(dbid);
+    return this.dispatch(CONST.PUT, this.connectionConfig.dbURL(), dbDoc);
+  }
+  const errmsg = `Update database error - you must specify a valid database id - ${dbid} is invalid`;
+  return Promise.reject(
+    new Error(ErrorMessage.getInvalidParameterMessage(CONST.UPDATE_DATABASE, errmsg)),
+  );
+};
+
+WOQLClient.prototype.updateDatabase = function (dbDoc) {
+  const dbid = dbDoc.id || this.db();
+  const org = dbDoc.organization || this.organization();
+  return this.createDatabase(dbid, dbDoc, org);
+};
+
+/**
  * Deletes a database from a TerminusDB server
  * @param {string} dbId The id of the database to be deleted
  * @param {string} [orgId] the id of the organization to which the database belongs
@@ -964,17 +993,6 @@ WOQLClient.prototype.prepareRevisionControlArgs = function (rc_args) {
   if (!rc_args || typeof rc_args !== 'object') return false;
   if (!rc_args.author) rc_args.author = this.author();
   return rc_args;
-};
-
-/**
- *  update the database details
- * @param {object} dbDoc - an object that describe the database details
- * @returns {Promise}  A promise that returns the call response object, or an Error if rejected.
- */
-WOQLClient.prototype.updateDatabase = function (dbDoc) {
-  const dbid = dbDoc.id || this.db();
-  const org = dbDoc.organization || this.organization();
-  return this.createDatabase(dbid, dbDoc, org);
 };
 
 /**

--- a/lib/woqlClient.js
+++ b/lib/woqlClient.js
@@ -481,12 +481,6 @@ WOQLClient.prototype.updateDatabase = function (dbDoc) {
   );
 };
 
-WOQLClient.prototype.updateDatabase = function (dbDoc) {
-  const dbid = dbDoc.id || this.db();
-  const org = dbDoc.organization || this.organization();
-  return this.createDatabase(dbid, dbDoc, org);
-};
-
 /**
  * Deletes a database from a TerminusDB server
  * @param {string} dbId The id of the database to be deleted


### PR DESCRIPTION
The client incorrectly used the createDatabase stub and used POST instead of PUT to update the data product details. Client is updated with a separate implementation of updateDatabase.

Fixes #246 