### PR TITLE
WOQLClient: Fix JSDoc

### DIFF
--- a/docs/api/woqlclient.md
+++ b/docs/api/woqlclient.md
@@ -11,9 +11,6 @@ with a TerminusDB server API, the WOQLClient class is all you will need.
 
 **License**: Apache Version 2  
 
-## module_WOQLClient..WOQLClient
-## WOQLClient~WOQLClient
-
 ## new WOQLClient(serverUrl, [params])
 
 | Param | Type | Description |
@@ -51,6 +48,8 @@ async function getSchema() {
      const schema = await client.getSchema()
 }
 ```
+
+## TerminusDB Client API
 
 ## Connect
 ##### ~~woqlClient.connect([params]) ⇒ <code>Promise</code>~~
@@ -260,21 +259,21 @@ Fetch updates to a remote database to a remote repository with the local databas
 | remoteId | <code>string</code> | if of the remote to fetch (eg: 'origin') |
 
 
-## module_WOQLClient..WOQLClient+local_auth
+## local_auth
 ##### ~~woqlClient.local\_auth~~
 ***Deprecated***
 
 Use [#localAuth](#localAuth) instead.
 
 
-## module_WOQLClient..WOQLClient+remote_auth
+## remote_auth
 ##### ~~woqlClient.remote\_auth~~
 ***Deprecated***
 
 Use [#remoteAuth](#remoteAuth) instead.
 
 
-## module_WOQLClient..WOQLClient+setApiKey
+## setApiKey
 ##### woqlClient.setApiKey(accessToken)
 set the api key to access the cloud resources
 
@@ -284,7 +283,7 @@ set the api key to access the cloud resources
 | accessToken | <code>string</code> | 
 
 
-## module_WOQLClient..WOQLClient+customHeaders
+## customHeaders
 ##### woqlClient.customHeaders(customHeaders) ⇒ <code>object</code>
 add extra headers to your request
 
@@ -294,26 +293,26 @@ add extra headers to your request
 | customHeaders | <code>object</code> | 
 
 
-## module_WOQLClient..WOQLClient+copy
-##### woqlClient.copy() ⇒ <code>WOQLClient</code>
+## copy
+##### woqlClient.copy() ⇒ [<code>WOQLClient</code>](#WOQLClient)
 creates a copy of the client with identical internal state and context
 useful if we want to change context for a particular API call without changing
 the current client context
 
-**Returns**: <code>WOQLClient</code> - new client object with identical state to original but
+**Returns**: [<code>WOQLClient</code>](#WOQLClient) - new client object with identical state to original but
 which can be manipulated independently  
 **Example**  
 ```javascript
 let newClient = client.copy()
 ```
 
-## module_WOQLClient..WOQLClient+server
+## server
 ##### woqlClient.server() ⇒ <code>string</code>
 Gets the current connected server url
 it can only be set creating a new WOQLCLient instance
 
 
-## module_WOQLClient..WOQLClient+api
+## api
 ##### woqlClient.api() ⇒ <code>string</code>
 Retrieve the URL of the server’s API base that we are currently connected to
 
@@ -324,7 +323,7 @@ to (typically server() + “api/”)
 let api_url = client.api()
 ```
 
-## module_WOQLClient..WOQLClient+organization
+## organization
 ##### woqlClient.organization([orgId]) ⇒ <code>string</code> \| <code>boolean</code>
 Gets/Sets the client’s internal organization context value, if you change the organization
 name the databases list will be set to empty
@@ -339,7 +338,7 @@ name the databases list will be set to empty
 client.organization("admin")
 ```
 
-## module_WOQLClient..WOQLClient+hasDatabase
+## hasDatabase
 ##### woqlClient.hasDatabase([orgName], [dbName]) ⇒ <code>Promise</code>
 Checks if a database exists
 
@@ -362,7 +361,7 @@ async function executeIfDatabaseExists(f){
 }
 ```
 
-## module_WOQLClient..WOQLClient+getDatabases
+## getDatabases
 ##### woqlClient.getDatabases() ⇒ <code>Promise</code>
 Gets the organization's databases list.
 
@@ -376,7 +375,7 @@ async function callGetDatabases(){
 }
 ```
 
-## module_WOQLClient..WOQLClient+databases
+## databases
 ##### woqlClient.databases([dbList]) ⇒ <code>array</code>
 Set/Get the organization's databases list (id, label, comment) that the current
 user has access to on the server.
@@ -396,18 +395,18 @@ async function callGetDatabases(){
 }
 ```
 
-## module_WOQLClient..WOQLClient+user
+## user
 ##### woqlClient.user() ⇒ <code>Object</code>
 Gets the current user object as returned by the connect capabilities response
 user has fields: [id, name, notes, author]
 
 
-## module_WOQLClient..WOQLClient+userOrganization
+## userOrganization
 ##### woqlClient.userOrganization() ⇒ <code>string</code>
 **Returns**: <code>string</code> - the user organization name  
 **Desription**: Gets the user's organization id  
 
-## module_WOQLClient..WOQLClient+databaseInfo
+## databaseInfo
 ##### woqlClient.databaseInfo([dbName]) ⇒ <code>object</code>
 Gets the database's details
 
@@ -418,7 +417,7 @@ Gets the database's details
 | [dbName] | <code>string</code> | the datbase name |
 
 
-## module_WOQLClient..WOQLClient+db
+## db
 ##### woqlClient.db([dbId]) ⇒ <code>string</code> \| <code>boolean</code>
 Sets / Gets the current database
 
@@ -433,12 +432,12 @@ Sets / Gets the current database
 client.db("mydb")
 ```
 
-## module_WOQLClient..WOQLClient+setSystemDb
+## setSystemDb
 ##### woqlClient.setSystemDb()
 Sets the internal client context to allow it to talk to the server’s internal system database
 
 
-## module_WOQLClient..WOQLClient+repo
+## repo
 ##### woqlClient.repo([repoId]) ⇒ <code>string</code>
 Gets / Sets the client’s internal repository context value (defaults to ‘local’)
 
@@ -453,7 +452,7 @@ Gets / Sets the client’s internal repository context value (defaults to ‘loc
 client.repo("origin")
 ```
 
-## module_WOQLClient..WOQLClient+checkout
+## checkout
 ##### woqlClient.checkout([branchId]) ⇒ <code>string</code>
 Gets/Sets the client’s internal branch context value (defaults to ‘main’)
 
@@ -464,7 +463,7 @@ Gets/Sets the client’s internal branch context value (defaults to ‘main’)
 | [branchId] | <code>string</code> | the branch id to set the context to |
 
 
-## module_WOQLClient..WOQLClient+ref
+## ref
 ##### woqlClient.ref([commitId]) ⇒ <code>string</code> \| <code>boolean</code>
 Sets / gets the current ref pointer (pointer to a commit within a branch)
 Reference ID or Commit ID are unique hashes that are created whenever a new commit is recorded
@@ -480,7 +479,7 @@ Reference ID or Commit ID are unique hashes that are created whenever a new comm
 client.ref("mkz98k2h3j8cqjwi3wxxzuyn7cr6cw7")
 ```
 
-## module_WOQLClient..WOQLClient+localAuth
+## localAuth
 ##### woqlClient.localAuth([newCredential]) ⇒ <code>typedef.CredentialObj</code> \| <code>boolean</code>
 Sets/Gets set the database basic connection credential
 
@@ -494,7 +493,7 @@ Sets/Gets set the database basic connection credential
 client.localAuth({user:"admin","key":"mykey","type":"basic"})
 ```
 
-## module_WOQLClient..WOQLClient+remoteAuth
+## remoteAuth
 ##### woqlClient.remoteAuth([newCredential]) ⇒ <code>typedef.CredentialObj</code> \| <code>boolean</code>
 Sets/Gets the jwt token for authentication
 we need this to connect 2 terminusdb server to each other for push, pull, clone actions
@@ -509,7 +508,7 @@ we need this to connect 2 terminusdb server to each other for push, pull, clone 
 client.remoteAuth({"key":"dhfmnmjglkrelgkptohkn","type":"jwt"})
 ```
 
-## module_WOQLClient..WOQLClient+author
+## author
 ##### woqlClient.author() ⇒ <code>string</code>
 Gets the string that will be written into the commit log for the current user
 
@@ -519,7 +518,7 @@ Gets the string that will be written into the commit log for the current user
 client.author()
 ```
 
-## module_WOQLClient..WOQLClient+set
+## set
 ##### woqlClient.set(params)
 
 | Param | Type | Description |
@@ -533,7 +532,7 @@ sets several of the internal state values in a single call
 client.set({key: "mypass", branch: "dev", repo: "origin"})
 ```
 
-## module_WOQLClient..WOQLClient+resource
+## resource
 ##### woqlClient.resource(resourceType, [resourceId]) ⇒ <code>string</code>
 Generates a resource string for the required context
 of the current context for "commits" "meta" "branch" and "ref" special resources
@@ -550,7 +549,7 @@ of the current context for "commits" "meta" "branch" and "ref" special resources
 const branch_resource = client.resource("branch")
 ```
 
-## module_WOQLClient..WOQLClient+updateDatabase
+## updateDatabase
 ##### woqlClient.updateDatabase(dbId, dbDetails, [orgId]) ⇒ <code>Promise</code>
 Update a database in TerminusDB server
 
@@ -567,7 +566,7 @@ Update a database in TerminusDB server
 client.updateDatabase({id: "mydb", label: "My Database", comment: "Testing"})
 ```
 
-## module_WOQLClient..WOQLClient+insertTriples
+## insertTriples
 ##### woqlClient.insertTriples(graphType, turtle, commitMsg) ⇒ <code>Promise</code>
 Appends the passed turtle to the contents of a graph
 
@@ -580,7 +579,7 @@ Appends the passed turtle to the contents of a graph
 | commitMsg | <code>string</code> | Textual message describing the reason for the update |
 
 
-## module_WOQLClient..WOQLClient+message
+## message
 ##### woqlClient.message(message, [pathname]) ⇒ <code>Promise</code>
 Sends a message to the server
 
@@ -592,7 +591,7 @@ Sends a message to the server
 | [pathname] | <code>string</code> | a server path to send the message to |
 
 
-## module_WOQLClient..WOQLClient+action
+## action
 ##### woqlClient.action(actionName, [payload]) ⇒ <code>Promise</code>
 Sends an action to the server
 
@@ -604,7 +603,7 @@ Sends an action to the server
 | [payload] | <code>object</code> | a request body call |
 
 
-## module_WOQLClient..WOQLClient+info
+## info
 ##### woqlClient.info() ⇒ <code>Promise</code>
 Gets TerminusDB Server Information
 
@@ -614,7 +613,7 @@ Gets TerminusDB Server Information
 client.info()
 ```
 
-## module_WOQLClient..WOQLClient+squashBranch
+## squashBranch
 ##### woqlClient.squashBranch(branchId, commitMsg) ⇒ <code>Promise</code>
 Squash branch commits
 
@@ -626,7 +625,7 @@ Squash branch commits
 | commitMsg | <code>string</code> | Textual message describing the reason for the update |
 
 
-## module_WOQLClient..WOQLClient+resetBranch
+## resetBranch
 ##### woqlClient.resetBranch(branchId, commitId) ⇒ <code>Promise</code>
 Reset branch to a commit id, Reference ID or Commit ID are unique hashes that are
 created whenever a new commit is recorded
@@ -639,7 +638,7 @@ created whenever a new commit is recorded
 | commitId | <code>string</code> | Reference ID or Commit ID |
 
 
-## module_WOQLClient..WOQLClient+optimizeBranch
+## optimizeBranch
 ##### woqlClient.optimizeBranch(branchId) ⇒ <code>Promise</code>
 Optimize db branch
 
@@ -650,7 +649,7 @@ Optimize db branch
 | branchId | <code>string</code> | local identifier of the new branch |
 
 
-## module_WOQLClient..WOQLClient+deleteBranch
+## deleteBranch
 ##### woqlClient.deleteBranch(branchId) ⇒ <code>Promise</code>
 Deletes a branch from database
 
@@ -661,7 +660,7 @@ Deletes a branch from database
 | branchId | <code>string</code> | local identifier of the branch |
 
 
-## module_WOQLClient..WOQLClient+reset
+## reset
 ##### woqlClient.reset(commitPath) ⇒ <code>Promise</code>
 Reset the current branch HEAD to the specified commit path
 
@@ -672,7 +671,7 @@ Reset the current branch HEAD to the specified commit path
 | commitPath | <code>string</code> | The commit path to set the current branch to |
 
 
-## module_WOQLClient..WOQLClient+dispatch
+## dispatch
 ##### woqlClient.dispatch() ⇒ <code>Promise</code>
 Common request dispatch function
 
@@ -688,7 +687,7 @@ Common request dispatch function
 | [compress] | <code>boolean</code> | If true, compress the data if it is bigger than 1024 bytes |
 
 
-## module_WOQLClient..WOQLClient+generateCommitInfo
+## generateCommitInfo
 ##### woqlClient.generateCommitInfo(msg, [author]) ⇒ <code>object</code>
 Generates the json structure for commit messages
 
@@ -699,7 +698,7 @@ Generates the json structure for commit messages
 | [author] | <code>string</code> | optional author id string - if absent current user id will be used |
 
 
-## module_WOQLClient..WOQLClient+generateCommitDescriptor
+## generateCommitDescriptor
 ##### woqlClient.generateCommitDescriptor(commitId)
 Generates the json structure for commit descriptor
 
@@ -709,7 +708,7 @@ Generates the json structure for commit descriptor
 | commitId | <code>string</code> | a valid commit id o |
 
 
-## module_WOQLClient..WOQLClient+prepareRevisionControlArgs
+## prepareRevisionControlArgs
 ##### woqlClient.prepareRevisionControlArgs([rc_args]) ⇒ <code>object</code> \| <code>boolean</code>
 Adds an author string (from the user object returned by connect) to the commit message.
 
@@ -719,7 +718,7 @@ Adds an author string (from the user object returned by connect) to the commit m
 | [rc_args] | <code>object</code> | 
 
 
-## module_WOQLClient..WOQLClient+addDocument
+## addDocument
 ##### woqlClient.addDocument(json, [params], [dbId], [string], [lastDataVersion], [getDataVersion]) ⇒ <code>Promise</code>
 to add a new document or a list of new documents into the instance or the schema graph.
 
@@ -777,7 +776,7 @@ const response1 = await client.addDocument(json, {"graph_type": "schema"},
 )
 ```
 
-## module_WOQLClient..WOQLClient+queryDocument
+## queryDocument
 ##### ~~woqlClient.queryDocument(query, [params], [dbId], [branch], [lastDataVersion], [getDataVersion]) ⇒ <code>Promise</code>~~
 ***Deprecated***
 
@@ -839,7 +838,7 @@ console.log(response);
  );
 ```
 
-## module_WOQLClient..WOQLClient+getDocument
+## getDocument
 ##### woqlClient.getDocument([params], [dbId], [branch], [lastDataVersion], [getDataVersion], [query]) ⇒ <code>Promise</code>
 **Returns**: <code>Promise</code> - A promise that returns the call response object or object having *result*
 and *dataVersion* object if ***getDataVersion*** parameter is true, or an Error if rejected.  
@@ -898,7 +897,7 @@ const response1 = await client.getDocument({"graph_type":"schema","as_list":true
 )
 ```
 
-## module_WOQLClient..WOQLClient+updateDocument
+## updateDocument
 ##### woqlClient.updateDocument(json, [params], [dbId], [message], [lastDataVersion], [getDataVersion], [create]) ⇒ <code>Promise</code>
 **Returns**: <code>Promise</code> - A promise that returns the call response object or object having *result*
 and *dataVersion* object if ***getDataVersion*** parameter is true, or an Error if rejected.  
@@ -972,7 +971,7 @@ const response1 = await client.updateDocument(
     );
 ```
 
-## module_WOQLClient..WOQLClient+deleteDocument
+## deleteDocument
 ##### woqlClient.deleteDocument([params], [dbId], [message], [lastDataVersion], [getDataVersion]) ⇒ <code>Promise</code>
 to delete the document
 
@@ -1019,7 +1018,7 @@ const response1 = await client.deleteDocument({"graph_type":"schema",
 )
 ```
 
-## module_WOQLClient..WOQLClient+getSchemaFrame
+## getSchemaFrame
 ##### woqlClient.getSchemaFrame([type], [dbId]) ⇒ <code>Promise</code>
 The purpose of this method is to quickly discover the supported fields of a particular type.
 
@@ -1035,7 +1034,7 @@ The purpose of this method is to quickly discover the supported fields of a part
 client.getSchemaFrame("Country")
 ```
 
-## module_WOQLClient..WOQLClient+getSchema
+## getSchema
 ##### woqlClient.getSchema([dbId], [branch]) ⇒ <code>Promise</code>
 get the database schema in json format
 
@@ -1051,7 +1050,7 @@ get the database schema in json format
 client.getSchema()
 ```
 
-## module_WOQLClient..WOQLClient+getClasses
+## getClasses
 ##### woqlClient.getClasses([dbId]) ⇒ <code>Promise</code>
 get all the schema classes (documents,subdocuments,abstracts)
 
@@ -1066,7 +1065,7 @@ get all the schema classes (documents,subdocuments,abstracts)
 client.getClasses()
 ```
 
-## module_WOQLClient..WOQLClient+getEnums
+## getEnums
 ##### woqlClient.getEnums([dbId]) ⇒ <code>Promise</code>
 get all the Enum Objects
 
@@ -1081,7 +1080,7 @@ get all the Enum Objects
 client.getEnums()
 ```
 
-## module_WOQLClient..WOQLClient+getClassDocuments
+## getClassDocuments
 ##### woqlClient.getClassDocuments([dbId]) ⇒ <code>Promise</code>
 get all the Document Classes (no abstract or subdocument)
 
@@ -1096,7 +1095,7 @@ get all the Document Classes (no abstract or subdocument)
 client.getClassDocuments()
 ```
 
-## module_WOQLClient..WOQLClient+getBranches
+## getBranches
 ##### woqlClient.getBranches([dbId]) ⇒ <code>Promise</code>
 get the database collections list
 
@@ -1111,7 +1110,7 @@ get the database collections list
 client.getBranches()
 ```
 
-## module_WOQLClient..WOQLClient+getCommitsLog
+## getCommitsLog
 ##### woqlClient.getCommitsLog([dbId]) ⇒ <code>Promise</code>
 get the database collections list
 
@@ -1126,7 +1125,7 @@ get the database collections list
 client.getCommitsLog()
 ```
 
-## module_WOQLClient..WOQLClient+getPrefixes
+## getPrefixes
 ##### woqlClient.getPrefixes([dbId]) ⇒ <code>Promise</code>
 get the database prefixes object
 
@@ -1146,7 +1145,7 @@ client.getPrefixes()
 '@type': 'Context'}
 ```
 
-## module_WOQLClient..WOQLClient+getUserOrganizations
+## getUserOrganizations
 ##### woqlClient.getUserOrganizations() ⇒ <code>Promise</code>
 Get the list of the user's organizations and the database related
 
@@ -1159,7 +1158,7 @@ async funtion callGetUserOrganizations(){
 }
 ```
 
-## module_WOQLClient..WOQLClient+userOrganizations
+## userOrganizations
 ##### woqlClient.userOrganizations([orgList]) ⇒ <code>array</code>
 Get/Set the list of the user's organizations (id, organization, label, comment).
 
@@ -1177,7 +1176,7 @@ async funtion callGetUserOrganizations(){
 }
 ```
 
-## module_WOQLClient..WOQLClient+getJSONDiff
+## getJSONDiff
 ##### woqlClient.getJSONDiff(before, after, [options]) ⇒ <code>Promise</code>
 Get the patch of difference between two documents.
 
@@ -1202,7 +1201,7 @@ client.getJSONDiff(
 // name: { '@after': 'Janine', '@before': 'Jane', '@op': 'SwapValue' }}
 ```
 
-## module_WOQLClient..WOQLClient+getVersionObjectDiff
+## getVersionObjectDiff
 ##### woqlClient.getVersionObjectDiff(dataVersion, jsonObject, id, [options]) ⇒ <code>Promise</code>
 Get the patch of difference between two documents.
 
@@ -1224,7 +1223,7 @@ client.getVersionObjectDiff("main",jsonObj
 })
 ```
 
-## module_WOQLClient..WOQLClient+getVersionDiff
+## getVersionDiff
 ##### woqlClient.getVersionDiff(beforeVersion, afterVersion, [id], [options]) ⇒ <code>Promise</code>
 Get the patch of difference between branches or commits.
 
@@ -1264,7 +1263,7 @@ client.getVersionDiff("main","mybranch",options).then(diffResult=>{
 })
 ```
 
-## module_WOQLClient..WOQLClient+apply
+## apply
 ##### woqlClient.apply(beforeVersion, afterVersion, message, [matchFinalState], [options])
 Diff two different commits and apply changes on the current branch/commit.
 If you would like to change branch or commit before apply use client.checkout("branchName")
@@ -1286,7 +1285,7 @@ client.apply("main","mybranch","merge main").then(result=>{
 })
 ```
 
-## module_WOQLClient..WOQLClient+patch
+## patch
 ##### woqlClient.patch(before, patch) ⇒ <code>Promise</code>
 Patch the difference between two documents.
 
@@ -1308,7 +1307,7 @@ let patch = await client.patch( { "@id": "Person/Jane", "@type": "Person", name:
 diffPatch);
 ```
 
-## module_WOQLClient..WOQLClient+sendCustomRequest
+## sendCustomRequest
 ##### woqlClient.sendCustomRequest(requestType, customRequestURL, [payload]) ⇒ <code>Promise</code>
 Call a custom Api endpoit
 

--- a/lib/woqlClient.js
+++ b/lib/woqlClient.js
@@ -15,8 +15,8 @@ const WOQLQuery = require('./query/woqlCore');
 
 /**
  * @license Apache Version 2
- * @module WOQLClient
- * @description The core functionality of the TerminusDB javascript client is
+ * @class
+ * @classdesc The core functionality of the TerminusDB javascript client is
  * defined in the WOQLClient class - in the woqlClient.js file. This class provides
  * methods which allow you to directly get and set all of the configuration and API
  * endpoints of the client. The other parts of the WOQL core - connectionConfig.js


### PR DESCRIPTION
The documentation contained very weird `module__` prefixes. This was because we were documenting the WOQLClient class as a module, even though it is a class instead of a module. This fixes the generated documentation to be much nicer.