### PR TITLE
Do not transform commit ids in resetBranch

### DIFF
--- a/lib/woqlClient.js
+++ b/lib/woqlClient.js
@@ -750,11 +750,10 @@ WOQLClient.prototype.squashBranch = function (branchId, commitMsg) {
 WOQLClient.prototype.resetBranch = function (branchId, commitId) {
   if (commitId && branchId) {
     // eslint-disable-next-line camelcase
-    const commit_descriptor = this.generateCommitDescriptor(commitId);
     return this.dispatch(
       CONST.RESET_BRANCH,
       this.connectionConfig.resetBranchUrl(branchId),
-      commit_descriptor,
+      { commit_descriptor: commitId },
     );
   }
   const errmsg = 'Branch parameter error - you must specify a valid new branch id and a commit message';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@terminusdb/terminusdb-client",
-  "version": "10.0.25",
+  "version": "10.0.26",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@terminusdb/terminusdb-client",
-      "version": "10.0.25",
+      "version": "10.0.26",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.25.0",


### PR DESCRIPTION
resetBranch was gluing a commit path in front of commit ids. This makes it inconvenient to work with squash, as squash returns full commit paths.
The endpoint actually accepts both raw ids and commit paths, so there's no reason to do this transform. It is also not happening in the `reset()` version (the version of this operation that works on the currently active branch).

This PR removes the transformation call and just passes through the commit id.