### PR TITLE
fix WOQLClient.getCommitsLog with selected branch

### DIFF
--- a/lib/woqlClient.js
+++ b/lib/woqlClient.js
@@ -1516,7 +1516,7 @@ WOQLClient.prototype.getBranches = function (dbId) {
 WOQLClient.prototype.getCommitsLog = function (start = 0, count = 1) {
   return this.dispatch(
     CONST.GET,
-    `${this.connectionConfig.log()}?start=${start}&count=${count}`,
+    `${this.connectionConfig.log()}/${this.connectionConfig.repo()}/branch/${this.connectionConfig.branch()}?start=${start}&count=${count}`,
   );
 };
 


### PR DESCRIPTION
The client request for WOQLClient.getCommitsLog() can now fetch the commits for the selected branch. Before this fix only commits from the 'main' branch were shown.