### PR TITLE
fix(woql): Add evaluate() method for fluent/chained query style

### DIFF
--- a/lib/query/woqlQuery.js
+++ b/lib/query/woqlQuery.js
@@ -921,6 +921,19 @@ WOQLQuery.prototype.eval = function (arithExp, resultVarName) {
 };
 
 /**
+ * Evaluates the passed arithmetic expression and generates or matches the result value.
+ * Alias for eval() to support both naming conventions in fluent/chained style.
+ * @param {object|WOQLQuery|string} arithExp - A WOQL query containing a valid arithmetic expression
+ * @param {string|number|Var} resultVarName - Either a variable to store the result, or a numeric
+ * literal to test against the evaluated expression
+ * @returns {WOQLQuery}
+ */
+
+WOQLQuery.prototype.evaluate = function (arithExp, resultVarName) {
+  return this.eval(arithExp, resultVarName);
+};
+
+/**
  * Adds the numbers together
  * @param {...(string|number|Var)} args - a variable or numeric containing the values to add
  * @returns {WOQLQuery} A WOQLQuery which contains the addition expression

--- a/test/woql.spec.js
+++ b/test/woql.spec.js
@@ -190,6 +190,34 @@ describe('woql queries', () => {
     expect(woqlObject.json()).to.eql(woqlMathJson.evalJson);
   });
 
+  it('check the evaluate method (functional style)', () => {
+    const woqlObject = WOQL.evaluate('1+2', 'b');
+    expect(woqlObject.json()).to.eql(woqlMathJson.evalJson);
+  });
+
+  it('check the evaluate method (fluent style)', () => {
+    // Test the reported bug: WOQL.limit(100).evaluate(...)
+    const woqlObject = WOQL.limit(100).evaluate(WOQL.times(2, 3), 'v:result');
+    const json = woqlObject.json();
+    
+    // Should have Limit with nested query
+    expect(json).to.have.property('@type', 'Limit');
+    expect(json).to.have.property('limit', 100);
+    expect(json).to.have.property('query');
+    
+    // Nested query should be Eval
+    expect(json.query).to.have.property('@type', 'Eval');
+    expect(json.query).to.have.property('expression');
+    expect(json.query.expression).to.have.property('@type', 'Times');
+  });
+
+  it('check evaluate and eval produce identical results', () => {
+    const withEval = WOQL.limit(10).eval(WOQL.plus(5, 3), 'x');
+    const withEvaluate = WOQL.limit(10).evaluate(WOQL.plus(5, 3), 'x');
+    
+    expect(withEval.json()).to.deep.eql(withEvaluate.json());
+  });
+
   it('check the minus method', () => {
     const woqlObject = WOQL.minus('2', '1');
     expect(woqlObject.json()).to.eql(woqlMathJson.minusJson);


### PR DESCRIPTION
Fixes issue #317 where WOQL.evaluate() only existed as a functional method but was missing from the WOQLQuery prototype for fluent/chained style.

## Problem:
Users reported error: "WOQL.limit(...).evaluate is not a function"
- WOQL.evaluate() worked: WOQL.evaluate(expr, var)
- WOQL.limit().evaluate() failed: "evaluate is not a function"

## Root Cause:
- WOQLQuery.prototype.eval() existed for chaining
- WOQLQuery.prototype.evaluate() was missing
- WOQL.evaluate() functional wrapper existed but called eval() internally

## Solution:
Added WOQLQuery.prototype.evaluate() as an alias to eval() for consistency.

**Implementation (woqlQuery.js):**
```javascript
WOQLQuery.prototype.evaluate = function (arithExp, resultVarName) {
  return this.eval(arithExp, resultVarName);
};
```

## Testing:
**3 new tests added:**
1. ✅ evaluate() functional style works
2. ✅ evaluate() fluent style works (WOQL.limit(100).evaluate(...))
3. ✅ evaluate() and eval() produce identical results

**All 153 tests passing**

## Usage:
```javascript
// Both naming conventions now work in functional style:
WOQL.eval(WOQL.times(2, 3), 'result')
WOQL.evaluate(WOQL.times(2, 3), 'result')

// Both naming conventions now work in fluent style:
WOQL.limit(100).eval(WOQL.times(2, 3), 'result')
WOQL.limit(100).evaluate(WOQL.times(2, 3), 'result')  // ✅ Now works!
```

Resolves #317