### PR TITLE
Add upsert and merge_repeats behaviour to client

### DIFF
--- a/lib/typedef.js
+++ b/lib/typedef.js
@@ -38,6 +38,10 @@ const { ACTIONS } = Utils.ACTIONS;
  *@property {boolean} [full_replace] - default is false, If true, all existing documents are deleted
  before inserting the posted documents. This allows the full replacement of the contents of a
  database. This is especially useful for replacing the schema.
+ *@property {boolean} [overwrite] - default is false, If true, existing documents with the same
+ ID will be overwritten instead of causing an error. This enables upsert behavior.
+ *@property {boolean} [merge_repeats] - default is false, If true, duplicate document IDs
+ in the same request are silently accepted instead of causing an error.
  */
 
 /**
@@ -49,6 +53,8 @@ const { ACTIONS } = Utils.ACTIONS;
  a new document if it doesn't exist.
  *@property {GraphType} [graph_type] - default is instance, instance|schema Used to switch between
  getting documents from the instance or the schema graph.
+ *@property {boolean} [merge_repeats] - default is false, If true, duplicate document IDs
+ in the same request are silently accepted instead of causing an error.
  */
 
 /**


### PR DESCRIPTION
The merge_repeats and overwrite behaviours were not possible to use from the client. Now upsert behaviours are possible, and when the same segments is written multiple times, it can be merged into one document.